### PR TITLE
update/MTC-3158-mautic5alpha-compatibility

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -3,7 +3,7 @@
 return [
     'name'        => 'Housekeeping by Leuchtfeuer',
     'description' => 'Database Cleanup Command to delete lead_event_log table entries, campaign_lead_event_log table entries, email_stats table entries where the referenced email entry is currently not published and email_stats_devices table entries.',
-    'version'     => '2.0.0',
+    'version'     => '3.0.0',
     'author'      => 'Leuchtfeuer Digital Marketing GmbH',
     'services'    => [
         'integrations' => [

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -38,37 +38,37 @@ class EventLogCleanup
 
     private array $params = [
         self::CAMPAIGN_LEAD_EVENTS => [
-            ':daysOld' => self::DEFAULT_DAYS,
+            'daysOld' => self::DEFAULT_DAYS,
         ],
         self::LEAD_EVENTS          => [
-            ':daysOld' => self::DEFAULT_DAYS,
+            'daysOld' => self::DEFAULT_DAYS,
         ],
         self::EMAIL_STATS          => [
-            ':daysOld' => self::DEFAULT_DAYS,
+            'daysOld' => self::DEFAULT_DAYS,
         ],
         self::EMAIL_STATS_TOKENS   => [
-            ':daysOld' => self::DEFAULT_DAYS,
+            'daysOld' => self::DEFAULT_DAYS,
         ],
         self::EMAIL_STATS_DEVICES  => [
-            ':daysOld' => self::DEFAULT_DAYS,
+            'daysOld' => self::DEFAULT_DAYS,
         ],
     ];
 
     private array $types = [
         self::CAMPAIGN_LEAD_EVENTS => [
-            ':daysOld' => \PDO::PARAM_INT,
+            'daysOld' => \PDO::PARAM_INT,
         ],
         self::LEAD_EVENTS          => [
-            ':daysOld' => \PDO::PARAM_INT,
+            'daysOld' => \PDO::PARAM_INT,
         ],
         self::EMAIL_STATS          => [
-            ':daysOld' => \PDO::PARAM_INT,
+            'daysOld' => \PDO::PARAM_INT,
         ],
         self::EMAIL_STATS_TOKENS   => [
-            ':daysOld' => \PDO::PARAM_INT,
+            'daysOld' => \PDO::PARAM_INT,
         ],
         self::EMAIL_STATS_DEVICES  => [
-            ':daysOld' => \PDO::PARAM_INT,
+            'daysOld' => \PDO::PARAM_INT,
         ],
     ];
 
@@ -96,7 +96,7 @@ class EventLogCleanup
 
         if (self::DEFAULT_DAYS !== $daysOld) {
             foreach ($this->params as $index => $item) {
-                $this->params[$index][':daysOld'] = $daysOld;
+                $this->params[$index]['daysOld'] = $daysOld;
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4",
+        "php": "^8.0.2",
         "ext-pdo": "*",
         "mautic/core-lib": "^3.0|^4.0"
     },


### PR DESCRIPTION
By the code changes the "Leuchtfeuer Housekeeping Bundle" will be compatible with Mautic 5 alpha; and it is still also compatible with Mautic 4.

Functional test: 
* Test all the functionality in a Mautic 5 alpha environement (for example in a local ddev Mautic 5 alpha environement), please.
* Test all the functionality of the plugin also in a Mautic 4 environement. 