### PR TITLE
Changed deletion logic of email_stats_devices

### DIFF
--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -36,7 +36,7 @@ class EventLogCleanup
         self::LEAD_EVENTS          => self::PREFIX.'lead_event_log WHERE date_added < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
         self::EMAIL_STATS          => self::PREFIX.'email_stats LEFT JOIN '.self::PREFIX.'emails ON '.self::PREFIX.'email_stats.email_id = '.self::PREFIX.'emails.id WHERE ('.self::PREFIX.'emails.is_published = 0 OR '.self::PREFIX.'emails.publish_down < DATE_SUB(NOW(),INTERVAL :daysOld DAY) OR '.self::PREFIX.'email_stats.email_id IS NULL) AND '.self::PREFIX.'email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
         self::EMAIL_STATS_TOKENS   => self::PREFIX.'email_stats '.self::SET.' WHERE date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY) AND tokens IS NOT NULL',
-        self::EMAIL_STATS_DEVICES  => self::PREFIX.'email_stats_devices LEFT JOIN '.self::PREFIX.'email_stats ON '.self::PREFIX.'email_stats.id = '.self::PREFIX.'email_stats_devices.stat_id WHERE '.self::PREFIX.'email_stats.id IS NULL OR '.self::PREFIX.'email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+        self::EMAIL_STATS_DEVICES  => self::PREFIX.'email_stats_devices WHERE '.self::PREFIX.'date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
     ];
 
     private array $update = [

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -36,7 +36,7 @@ class EventLogCleanup
         self::LEAD_EVENTS          => self::PREFIX.'lead_event_log WHERE date_added < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
         self::EMAIL_STATS          => self::PREFIX.'email_stats LEFT JOIN '.self::PREFIX.'emails ON '.self::PREFIX.'email_stats.email_id = '.self::PREFIX.'emails.id WHERE ('.self::PREFIX.'emails.is_published = 0 OR '.self::PREFIX.'emails.publish_down < DATE_SUB(NOW(),INTERVAL :daysOld DAY) OR '.self::PREFIX.'email_stats.email_id IS NULL) AND '.self::PREFIX.'email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
         self::EMAIL_STATS_TOKENS   => self::PREFIX.'email_stats '.self::SET.' WHERE date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY) AND tokens IS NOT NULL',
-        self::EMAIL_STATS_DEVICES  => self::PREFIX.'email_stats_devices WHERE '.self::PREFIX.'date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+        self::EMAIL_STATS_DEVICES  => self::PREFIX.'email_stats_devices WHERE '.self::PREFIX.'email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
     ];
 
     private array $update = [

--- a/Tests/Service/EventLogCleanupTest.php
+++ b/Tests/Service/EventLogCleanupTest.php
@@ -84,7 +84,7 @@ class EventLogCleanupTest extends TestCase
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
                 [
-                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
@@ -129,7 +129,7 @@ class EventLogCleanupTest extends TestCase
             ],
             [
                 [
-                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
@@ -169,7 +169,7 @@ class EventLogCleanupTest extends TestCase
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
                 [
-                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'SELECT COUNT(1) as cnt FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
@@ -234,7 +234,7 @@ class EventLogCleanupTest extends TestCase
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
                 [
-                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
@@ -279,7 +279,7 @@ class EventLogCleanupTest extends TestCase
             ],
             [
                 [
-                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
@@ -319,7 +319,7 @@ class EventLogCleanupTest extends TestCase
                     ['daysOld' => \PDO::PARAM_INT],
                 ],
                 [
-                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices LEFT JOIN prefix_table_email_stats ON prefix_table_email_stats.id = prefix_table_email_stats_devices.stat_id WHERE prefix_table_email_stats.id IS NULL OR prefix_table_email_stats.date_sent < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
+                    'DELETE prefix_table_email_stats_devices FROM prefix_table_email_stats_devices WHERE prefix_table_email_stats_devices.date_opened < DATE_SUB(NOW(),INTERVAL :daysOld DAY)',
                     ['daysOld' => $daysOld],
                     ['daysOld' => \PDO::PARAM_INT],
                 ],


### PR DESCRIPTION
Simplified the deletion logic of email_stats_devices to exclude a LEFT JOIN and improve the performance by quite a bit. Indicator of deletion will now be the email_stats_devices.date_opened instead if a LEFT JOIN to email_stats.