### PR TITLE
Feature - Add --aggregate-redirects to merge duplicate tracking links

### DIFF
--- a/Command/EventLogCleanupCommand.php
+++ b/Command/EventLogCleanupCommand.php
@@ -42,6 +42,13 @@ class EventLogCleanupCommand extends Command
                     new InputOption('email-stats-tokens', 't', InputOption::VALUE_NONE, 'Set only tokens fields in Email Stats Records to NULL. Important: This option can not be combined with any "-c", "-l" or "-m" flag in one command. And: If the option flag "-t" is not set, the NULL setting of tokens will not be done with the basis command, so if you just run mautic:leuchtfeuer:housekeeping without a flag)'),
                     new InputOption('cmp-id', 'i', InputOption::VALUE_OPTIONAL, 'Delete only campaign_lead_eventLog for a specific CampaignID. Implies --campaign-lead.', 'none'),
                     new InputOption('optimize-tables', 'o', InputOption::VALUE_NONE, 'Optimize all database tables after cleanup.'),
+                    new InputOption(
+                        'aggregate-redirects',
+                        'a',
+                        InputOption::VALUE_NONE,
+                        'Aggregate duplicate page_redirects entries (caused by multiple messenger workers). '
+                        .'Consolidates split click statistics per email. Safe: existing tracking URLs continue to work.'
+                    ),
                 ]
             )
             ->setHelp(
@@ -76,14 +83,64 @@ class EventLogCleanupCommand extends Command
 
                 Purge only page_hits records
                 <info>php %command.full_name% --page-hits</info>
+
+                Aggregate duplicate page_redirects entries (preview):
+                <info>php %command.full_name% --aggregate-redirects --dry-run</info>
+
+                Aggregate duplicate page_redirects entries:
+                <info>php %command.full_name% --aggregate-redirects</info>
+
+                Aggregate duplicate page_redirects and optimize tables:
+                <info>php %command.full_name% --aggregate-redirects --optimize-tables</info>
                 EOT
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $daysOld                              = (int) $input->getOption('days-old');
         $dryRun                               = $input->getOption('dry-run');
+        $aggregateRedirects                   = $input->getOption('aggregate-redirects');
+
+        if ($aggregateRedirects) {
+            $hasCleanupFlag = $input->getOption('campaign-lead')
+                || $input->getOption('lead')
+                || $input->getOption('email-stats')
+                || $input->getOption('email-stats-tokens')
+                || $input->getOption('page-hits')
+                || 'none' !== $input->getOption('cmp-id');
+
+            if ($hasCleanupFlag) {
+                $output->writeln('<error>The "--aggregate-redirects" flag cannot be combined with "-c", "-l", "-m", "-t", "-p", or "-i" flags.</error>');
+
+                return 1;
+            }
+
+            try {
+                $message = $this->eventLogCleanup->aggregateRedirects($dryRun, $output);
+            } catch (\Throwable $e) {
+                $output->writeln(sprintf('<error>Redirect aggregation failed: %s</error>', $e->getMessage()));
+
+                return 1;
+            }
+
+            $output->writeln('<info>'.$message.'<info>');
+
+            $optimizeTables = $input->getOption('optimize-tables');
+            if ($optimizeTables && !$dryRun) {
+                try {
+                    $message = $this->eventLogCleanup->optimizeTables($output);
+                    $output->writeln('<info>'.$message.'<info>');
+                } catch (\Throwable $e) {
+                    $output->writeln(sprintf('<error>Table optimization failed: %s</error>', $e->getMessage()));
+
+                    return 1;
+                }
+            }
+
+            return 0;
+        }
+
+        $daysOld                              = (int) $input->getOption('days-old');
         $campaignId                           = 'none' === $input->getOption('cmp-id') ? null : (int) $input->getOption('cmp-id');
         $operations                           = [
             EventLogCleanup::CAMPAIGN_LEAD_EVENTS => $input->getOption('campaign-lead') || null !== $campaignId,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ By default, entries older than 365 days are deleted from the CampaignLeadEventLo
 -t  | --email-stats-tokens      | Only set tokens fields in Email Stats Records to NULL instead of deleting the whole record
 -l  | --lead                    | Only entries from the lead_event_log table will be deleted.
 -p  | --page-hits               | Only entries from the page_hits table will be deleted.
+-a  | --aggregate-redirects     | Aggregate duplicate page_redirects entries caused by multiple messenger workers. Consolidates split click statistics per email. Existing tracking URLs continue to work. Cannot be combined with -c, -l, -m, -t, or -p.
 ```
 
 ### Notice

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -409,6 +409,18 @@ class EventLogCleanup
             // Phase B: Orphan hit cleanup
             $movedHits = 0;
             if ($orphanHitCount > 0) {
+                // Collect orphan redirect IDs before reassignment (to zero out stale counters later)
+                $orphanRedirectIds = $this->connection->executeQuery(
+                    'SELECT DISTINCT orphan.id '
+                        .'FROM '.$p.'page_hits ph '
+                        .'INNER JOIN '.$p.'page_redirects orphan ON ph.redirect_id = orphan.id '
+                        .'LEFT JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = orphan.id '
+                        .'INNER JOIN '.$p.'page_redirects winner ON winner.url = orphan.url AND winner.id != orphan.id '
+                        .'INNER JOIN '.$p.'channel_url_trackables wcut ON wcut.redirect_id = winner.id '
+                        ."AND wcut.channel = 'email' AND wcut.channel_id = ph.email_id "
+                        .'WHERE cut.redirect_id IS NULL'
+                )->fetchFirstColumn();
+
                 // Get orphan hit stats grouped by winner (before reassignment)
                 $orphanStats = $this->connection->executeQuery(
                     'SELECT winner.id as winner_id, wcut.channel, wcut.channel_id, '
@@ -469,6 +481,15 @@ class EventLogCleanup
                             'addUniqueHits' => \PDO::PARAM_INT,
                             'winnerId'      => \PDO::PARAM_INT,
                         ]
+                    );
+                }
+
+                // Zero out stale counters on orphan redirects
+                if (!empty($orphanRedirectIds)) {
+                    $this->connection->executeQuery(
+                        'UPDATE '.$p.'page_redirects SET hits = 0, unique_hits = 0 WHERE id IN (:ids)',
+                        ['ids' => array_map('intval', $orphanRedirectIds)],
+                        ['ids' => \Doctrine\DBAL\ArrayParameterType::INTEGER]
                     );
                 }
             }

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -26,6 +26,7 @@ class EventLogCleanup
     public const EMAIL_STATS_TOKENS   = 'email_stats_tokens';
     private const EMAIL_STATS_DEVICES = 'email_stats_devices';
     public const PAGE_HITS            = 'page_hits';
+    public const AGGREGATE_REDIRECTS  = 'aggregate_redirects';
 
     /**
      * @var array<string, string>
@@ -242,6 +243,248 @@ class EventLogCleanup
         }
 
         return $message.$postfix;
+    }
+
+    public function aggregateRedirects(bool $dryRun, OutputInterface $output): string
+    {
+        if (!$this->config->isPublished()) {
+            return 'Housekeeping by Leuchtfeuer is currently not enabled. To use it, please enable the plugin in your Mautic plugin management.';
+        }
+
+        $p = $this->dbPrefix;
+
+        // Phase A: Find duplicate groups (scoped per url + channel + channel_id)
+        $findDuplicatesSql = 'SELECT pr.url, cut.channel, cut.channel_id, '
+            .'MIN(pr.id) as winner_id, '
+            .'GROUP_CONCAT(pr.id ORDER BY pr.id) as all_ids, '
+            .'COUNT(*) as duplicate_count '
+            .'FROM '.$p.'page_redirects pr '
+            .'INNER JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = pr.id '
+            .'GROUP BY pr.url, cut.channel, cut.channel_id '
+            .'HAVING COUNT(*) > 1';
+
+        if ($output->isVerbose()) {
+            $output->writeln($findDuplicatesSql);
+        }
+
+        $duplicateGroups = $this->connection->executeQuery($findDuplicatesSql)->fetchAllAssociative();
+
+        $totalGroups = count($duplicateGroups);
+        $totalDuplicateRedirects = 0;
+        foreach ($duplicateGroups as $group) {
+            $allIds = array_map('intval', explode(',', (string) $group['all_ids']));
+            $totalDuplicateRedirects += count($allIds) - 1;
+        }
+
+        // Phase B: Count orphan hits (page_hits referencing redirects without trackable entries)
+        $orphanCountSql = 'SELECT COUNT(*) FROM '.$p.'page_hits ph '
+            .'INNER JOIN '.$p.'page_redirects orphan ON ph.redirect_id = orphan.id '
+            .'LEFT JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = orphan.id '
+            .'INNER JOIN '.$p.'page_redirects winner ON winner.url = orphan.url AND winner.id != orphan.id '
+            .'INNER JOIN '.$p.'channel_url_trackables wcut ON wcut.redirect_id = winner.id '
+            ."AND wcut.channel = 'email' AND wcut.channel_id = ph.email_id "
+            .'WHERE cut.redirect_id IS NULL';
+
+        if ($output->isVerbose()) {
+            $output->writeln($orphanCountSql);
+        }
+
+        $orphanHitCount = (int) $this->connection->executeQuery($orphanCountSql)->fetchOne();
+
+        // Dry run: report counts only
+        if ($dryRun) {
+            if (0 === $totalGroups && 0 === $orphanHitCount) {
+                return 'No duplicate redirects or orphan hits found. This is a dry run.';
+            }
+
+            $parts = [];
+            if ($totalGroups > 0) {
+                $parts[] = $totalGroups.' duplicate redirect groups ('.$totalDuplicateRedirects.' duplicate entries to consolidate)';
+            }
+            if ($orphanHitCount > 0) {
+                $parts[] = $orphanHitCount.' orphan hits to reassign';
+            }
+
+            return 'Found '.implode(' and ', $parts).'. This is a dry run.';
+        }
+
+        // Real run: nothing to do
+        if (0 === $totalGroups && 0 === $orphanHitCount) {
+            return 'No duplicate redirects or orphan hits found. Nothing to do.';
+        }
+
+        $this->connection->beginTransaction();
+
+        try {
+            $mergedGroups = 0;
+
+            // Phase A: Merge each duplicate group
+            foreach ($duplicateGroups as $group) {
+                $winnerId = (int) $group['winner_id'];
+                $allIds = array_map('intval', explode(',', (string) $group['all_ids']));
+                $loserIds = array_values(array_filter($allIds, static fn (int $id): bool => $id !== $winnerId));
+                $channel = (string) $group['channel'];
+                $channelId = (int) $group['channel_id'];
+
+                if (empty($loserIds)) {
+                    continue;
+                }
+
+                // Step 1: Move page_hits from losers to winner
+                $this->connection->executeQuery(
+                    'UPDATE '.$p.'page_hits SET redirect_id = :winnerId WHERE redirect_id IN (:loserIds)',
+                    ['winnerId' => $winnerId, 'loserIds' => $loserIds],
+                    ['winnerId' => \PDO::PARAM_INT, 'loserIds' => Connection::PARAM_INT_ARRAY]
+                );
+
+                // Step 2: Sum trackable stats from losers
+                $trackableStats = $this->connection->executeQuery(
+                    'SELECT COALESCE(SUM(hits), 0) as total_hits, COALESCE(SUM(unique_hits), 0) as total_unique_hits '
+                        .'FROM '.$p.'channel_url_trackables '
+                        .'WHERE redirect_id IN (:loserIds) AND channel = :channel AND channel_id = :channelId',
+                    ['loserIds' => $loserIds, 'channel' => $channel, 'channelId' => $channelId],
+                    ['loserIds' => Connection::PARAM_INT_ARRAY, 'channel' => \PDO::PARAM_STR, 'channelId' => \PDO::PARAM_INT]
+                )->fetchAssociative();
+
+                // Add loser stats to winner's trackable entry
+                $this->connection->executeQuery(
+                    'UPDATE '.$p.'channel_url_trackables SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits '
+                        .'WHERE redirect_id = :winnerId AND channel = :channel AND channel_id = :channelId',
+                    [
+                        'addHits'       => (int) $trackableStats['total_hits'],
+                        'addUniqueHits' => (int) $trackableStats['total_unique_hits'],
+                        'winnerId'      => $winnerId,
+                        'channel'       => $channel,
+                        'channelId'     => $channelId,
+                    ],
+                    [
+                        'addHits'       => \PDO::PARAM_INT,
+                        'addUniqueHits' => \PDO::PARAM_INT,
+                        'winnerId'      => \PDO::PARAM_INT,
+                        'channel'       => \PDO::PARAM_STR,
+                        'channelId'     => \PDO::PARAM_INT,
+                    ]
+                );
+
+                // Step 3: Delete loser trackable entries
+                $this->connection->executeQuery(
+                    'DELETE FROM '.$p.'channel_url_trackables WHERE redirect_id IN (:loserIds) AND channel = :channel AND channel_id = :channelId',
+                    ['loserIds' => $loserIds, 'channel' => $channel, 'channelId' => $channelId],
+                    ['loserIds' => Connection::PARAM_INT_ARRAY, 'channel' => \PDO::PARAM_STR, 'channelId' => \PDO::PARAM_INT]
+                );
+
+                // Step 4: Sum redirect stats from losers
+                $redirectStats = $this->connection->executeQuery(
+                    'SELECT COALESCE(SUM(hits), 0) as total_hits, COALESCE(SUM(unique_hits), 0) as total_unique_hits '
+                        .'FROM '.$p.'page_redirects WHERE id IN (:loserIds)',
+                    ['loserIds' => $loserIds],
+                    ['loserIds' => Connection::PARAM_INT_ARRAY]
+                )->fetchAssociative();
+
+                // Add loser stats to winner's redirect entry
+                $this->connection->executeQuery(
+                    'UPDATE '.$p.'page_redirects SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits WHERE id = :winnerId',
+                    [
+                        'addHits'       => (int) $redirectStats['total_hits'],
+                        'addUniqueHits' => (int) $redirectStats['total_unique_hits'],
+                        'winnerId'      => $winnerId,
+                    ],
+                    [
+                        'addHits'       => \PDO::PARAM_INT,
+                        'addUniqueHits' => \PDO::PARAM_INT,
+                        'winnerId'      => \PDO::PARAM_INT,
+                    ]
+                );
+
+                // Step 5: Zero out loser redirect stats (cosmetic, redirects still work)
+                $this->connection->executeQuery(
+                    'UPDATE '.$p.'page_redirects SET hits = 0, unique_hits = 0 WHERE id IN (:loserIds)',
+                    ['loserIds' => $loserIds],
+                    ['loserIds' => Connection::PARAM_INT_ARRAY]
+                );
+
+                ++$mergedGroups;
+            }
+
+            // Phase B: Orphan hit cleanup
+            $movedHits = 0;
+            if ($orphanHitCount > 0) {
+                // Get orphan hit stats grouped by winner (before reassignment)
+                $orphanStats = $this->connection->executeQuery(
+                    'SELECT winner.id as winner_id, wcut.channel, wcut.channel_id, '
+                        .'COUNT(*) as hit_count, COUNT(DISTINCT ph.lead_id) as unique_count '
+                        .'FROM '.$p.'page_hits ph '
+                        .'INNER JOIN '.$p.'page_redirects orphan ON ph.redirect_id = orphan.id '
+                        .'LEFT JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = orphan.id '
+                        .'INNER JOIN '.$p.'page_redirects winner ON winner.url = orphan.url AND winner.id != orphan.id '
+                        .'INNER JOIN '.$p.'channel_url_trackables wcut ON wcut.redirect_id = winner.id '
+                        ."AND wcut.channel = 'email' AND wcut.channel_id = ph.email_id "
+                        .'WHERE cut.redirect_id IS NULL '
+                        .'GROUP BY winner.id, wcut.channel, wcut.channel_id'
+                )->fetchAllAssociative();
+
+                // Reassign orphan hits to winners
+                $result = $this->connection->executeQuery(
+                    'UPDATE '.$p.'page_hits ph '
+                        .'INNER JOIN '.$p.'page_redirects orphan ON ph.redirect_id = orphan.id '
+                        .'LEFT JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = orphan.id '
+                        .'INNER JOIN '.$p.'page_redirects winner ON winner.url = orphan.url AND winner.id != orphan.id '
+                        .'INNER JOIN '.$p.'channel_url_trackables wcut ON wcut.redirect_id = winner.id '
+                        ."AND wcut.channel = 'email' AND wcut.channel_id = ph.email_id "
+                        .'SET ph.redirect_id = winner.id '
+                        .'WHERE cut.redirect_id IS NULL'
+                );
+                $movedHits = $result->rowCount();
+
+                // Update winner stats for moved orphan hits
+                foreach ($orphanStats as $stat) {
+                    $this->connection->executeQuery(
+                        'UPDATE '.$p.'channel_url_trackables SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits '
+                            .'WHERE redirect_id = :winnerId AND channel = :channel AND channel_id = :channelId',
+                        [
+                            'addHits'       => (int) $stat['hit_count'],
+                            'addUniqueHits' => (int) $stat['unique_count'],
+                            'winnerId'      => (int) $stat['winner_id'],
+                            'channel'       => $stat['channel'],
+                            'channelId'     => (int) $stat['channel_id'],
+                        ],
+                        [
+                            'addHits'       => \PDO::PARAM_INT,
+                            'addUniqueHits' => \PDO::PARAM_INT,
+                            'winnerId'      => \PDO::PARAM_INT,
+                            'channel'       => \PDO::PARAM_STR,
+                            'channelId'     => \PDO::PARAM_INT,
+                        ]
+                    );
+
+                    $this->connection->executeQuery(
+                        'UPDATE '.$p.'page_redirects SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits WHERE id = :winnerId',
+                        [
+                            'addHits'       => (int) $stat['hit_count'],
+                            'addUniqueHits' => (int) $stat['unique_count'],
+                            'winnerId'      => (int) $stat['winner_id'],
+                        ],
+                        [
+                            'addHits'       => \PDO::PARAM_INT,
+                            'addUniqueHits' => \PDO::PARAM_INT,
+                            'winnerId'      => \PDO::PARAM_INT,
+                        ]
+                    );
+                }
+            }
+
+            $this->connection->commit();
+        } catch (\Throwable $throwable) {
+            $this->connection->rollBack();
+            throw $throwable;
+        }
+
+        $message = 'Aggregated '.$mergedGroups.' duplicate redirect groups ('.$totalDuplicateRedirects.' duplicate entries consolidated).';
+        if ($movedHits > 0) {
+            $message .= ' Reassigned '.$movedHits.' orphan hits.';
+        }
+
+        return $message;
     }
 
     public function optimizeTables(OutputInterface $output): string

--- a/Tests/Service/EventLogCleanupTest.php
+++ b/Tests/Service/EventLogCleanupTest.php
@@ -75,6 +75,297 @@ class EventLogCleanupTest extends TestCase
         self::assertSame($message, $eventLogCleanup->deleteEventLogEntries(4, $campaignId, $dryRun, $operations, $output));
     }
 
+    public function testAggregateRedirectsPluginNotPublished(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('executeQuery');
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(false);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, 'prefix_table_', $config, $logger);
+        self::assertSame(
+            'Housekeeping by Leuchtfeuer is currently not enabled. To use it, please enable the plugin in your Mautic plugin management.',
+            $eventLogCleanup->aggregateRedirects(true, $output)
+        );
+    }
+
+    public function testAggregateRedirectsDryRunNoDuplicates(): void
+    {
+        $findDuplicatesResult = $this->createMock(Result::class);
+        $findDuplicatesResult->expects(self::once())->method('fetchAllAssociative')->willReturn([]);
+
+        $orphanCountResult = $this->createMock(Result::class);
+        $orphanCountResult->expects(self::once())->method('fetchOne')->willReturn(0);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))
+            ->method('executeQuery')
+            ->willReturnCallback(static function () use (&$findDuplicatesResult, &$orphanCountResult): Result {
+                if (null !== $findDuplicatesResult) {
+                    $result = $findDuplicatesResult;
+                    $findDuplicatesResult = null;
+
+                    return $result;
+                }
+
+                return $orphanCountResult;
+            });
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->method('isVerbose')->willReturn(false);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(true);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, 'prefix_table_', $config, $logger);
+        self::assertSame(
+            'No duplicate redirects or orphan hits found. This is a dry run.',
+            $eventLogCleanup->aggregateRedirects(true, $output)
+        );
+    }
+
+    public function testAggregateRedirectsDryRunWithDuplicates(): void
+    {
+        $findDuplicatesResult = $this->createMock(Result::class);
+        $findDuplicatesResult->expects(self::once())->method('fetchAllAssociative')->willReturn([
+            [
+                'url'             => 'http://example.com',
+                'channel'         => 'email',
+                'channel_id'      => 5,
+                'winner_id'       => 1,
+                'all_ids'         => '1,2,3',
+                'duplicate_count' => 3,
+            ],
+        ]);
+
+        $orphanCountResult = $this->createMock(Result::class);
+        $orphanCountResult->expects(self::once())->method('fetchOne')->willReturn(4);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))
+            ->method('executeQuery')
+            ->willReturnCallback(static function () use (&$findDuplicatesResult, &$orphanCountResult): Result {
+                if (null !== $findDuplicatesResult) {
+                    $result = $findDuplicatesResult;
+                    $findDuplicatesResult = null;
+
+                    return $result;
+                }
+
+                return $orphanCountResult;
+            });
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->method('isVerbose')->willReturn(false);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(true);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, 'prefix_table_', $config, $logger);
+        self::assertSame(
+            'Found 1 duplicate redirect groups (2 duplicate entries to consolidate) and 4 orphan hits to reassign. This is a dry run.',
+            $eventLogCleanup->aggregateRedirects(true, $output)
+        );
+    }
+
+    public function testAggregateRedirectsDryRunWithDuplicatesNoOrphans(): void
+    {
+        $findDuplicatesResult = $this->createMock(Result::class);
+        $findDuplicatesResult->expects(self::once())->method('fetchAllAssociative')->willReturn([
+            [
+                'url'             => 'http://example.com/page1',
+                'channel'         => 'email',
+                'channel_id'      => 10,
+                'winner_id'       => 5,
+                'all_ids'         => '5,15,25',
+                'duplicate_count' => 3,
+            ],
+            [
+                'url'             => 'http://example.com/page2',
+                'channel'         => 'email',
+                'channel_id'      => 10,
+                'winner_id'       => 6,
+                'all_ids'         => '6,16',
+                'duplicate_count' => 2,
+            ],
+        ]);
+
+        $orphanCountResult = $this->createMock(Result::class);
+        $orphanCountResult->expects(self::once())->method('fetchOne')->willReturn(0);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))
+            ->method('executeQuery')
+            ->willReturnCallback(static function () use (&$findDuplicatesResult, &$orphanCountResult): Result {
+                if (null !== $findDuplicatesResult) {
+                    $result = $findDuplicatesResult;
+                    $findDuplicatesResult = null;
+
+                    return $result;
+                }
+
+                return $orphanCountResult;
+            });
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->method('isVerbose')->willReturn(false);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(true);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, 'prefix_table_', $config, $logger);
+        self::assertSame(
+            'Found 2 duplicate redirect groups (3 duplicate entries to consolidate). This is a dry run.',
+            $eventLogCleanup->aggregateRedirects(true, $output)
+        );
+    }
+
+    public function testAggregateRedirectsRealRunSingleGroup(): void
+    {
+        $p = 'prefix_table_';
+
+        // Expected queries in order
+        $expectedQueries = [
+            // Query 1: Find duplicates
+            'SELECT pr.url, cut.channel, cut.channel_id, MIN(pr.id) as winner_id, GROUP_CONCAT(pr.id ORDER BY pr.id) as all_ids, COUNT(*) as duplicate_count FROM '.$p.'page_redirects pr INNER JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = pr.id GROUP BY pr.url, cut.channel, cut.channel_id HAVING COUNT(*) > 1',
+            // Query 2: Count orphans
+            'SELECT COUNT(*) FROM '.$p.'page_hits ph INNER JOIN '.$p.'page_redirects orphan ON ph.redirect_id = orphan.id LEFT JOIN '.$p.'channel_url_trackables cut ON cut.redirect_id = orphan.id INNER JOIN '.$p.'page_redirects winner ON winner.url = orphan.url AND winner.id != orphan.id INNER JOIN '.$p."channel_url_trackables wcut ON wcut.redirect_id = winner.id AND wcut.channel = 'email' AND wcut.channel_id = ph.email_id WHERE cut.redirect_id IS NULL",
+            // Query 3: UPDATE page_hits (move hits to winner)
+            'UPDATE '.$p.'page_hits SET redirect_id = :winnerId WHERE redirect_id IN (:loserIds)',
+            // Query 4: SELECT trackable stats from losers
+            'SELECT COALESCE(SUM(hits), 0) as total_hits, COALESCE(SUM(unique_hits), 0) as total_unique_hits FROM '.$p.'channel_url_trackables WHERE redirect_id IN (:loserIds) AND channel = :channel AND channel_id = :channelId',
+            // Query 5: UPDATE trackable stats on winner
+            'UPDATE '.$p.'channel_url_trackables SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits WHERE redirect_id = :winnerId AND channel = :channel AND channel_id = :channelId',
+            // Query 6: DELETE loser trackable entries
+            'DELETE FROM '.$p.'channel_url_trackables WHERE redirect_id IN (:loserIds) AND channel = :channel AND channel_id = :channelId',
+            // Query 7: SELECT redirect stats from losers
+            'SELECT COALESCE(SUM(hits), 0) as total_hits, COALESCE(SUM(unique_hits), 0) as total_unique_hits FROM '.$p.'page_redirects WHERE id IN (:loserIds)',
+            // Query 8: UPDATE redirect stats on winner
+            'UPDATE '.$p.'page_redirects SET hits = hits + :addHits, unique_hits = unique_hits + :addUniqueHits WHERE id = :winnerId',
+            // Query 9: Zero out loser redirect stats
+            'UPDATE '.$p.'page_redirects SET hits = 0, unique_hits = 0 WHERE id IN (:loserIds)',
+        ];
+
+        // Result mocks for each query
+        $findDuplicatesResult = $this->createMock(Result::class);
+        $findDuplicatesResult->expects(self::once())->method('fetchAllAssociative')->willReturn([
+            [
+                'url'             => 'http://test.com',
+                'channel'         => 'email',
+                'channel_id'      => 7,
+                'winner_id'       => 10,
+                'all_ids'         => '10,20',
+                'duplicate_count' => 2,
+            ],
+        ]);
+
+        $orphanCountResult = $this->createMock(Result::class);
+        $orphanCountResult->expects(self::once())->method('fetchOne')->willReturn(0);
+
+        $trackableStatsResult = $this->createMock(Result::class);
+        $trackableStatsResult->expects(self::once())->method('fetchAssociative')->willReturn([
+            'total_hits'        => 5,
+            'total_unique_hits' => 3,
+        ]);
+
+        $redirectStatsResult = $this->createMock(Result::class);
+        $redirectStatsResult->expects(self::once())->method('fetchAssociative')->willReturn([
+            'total_hits'        => 8,
+            'total_unique_hits' => 4,
+        ]);
+
+        $voidResult = $this->createMock(Result::class);
+
+        $resultMap = [
+            $findDuplicatesResult,
+            $orphanCountResult,
+            $voidResult, // UPDATE page_hits
+            $trackableStatsResult,
+            $voidResult, // UPDATE trackable stats
+            $voidResult, // DELETE trackables
+            $redirectStatsResult,
+            $voidResult, // UPDATE redirect stats
+            $voidResult, // Zero out losers
+        ];
+
+        $queryIndex = 0;
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(9))
+            ->method('executeQuery')
+            ->willReturnCallback(function (string $sql) use (&$queryIndex, $expectedQueries, $resultMap): Result {
+                self::assertSame($expectedQueries[$queryIndex], $sql, 'Query #'.($queryIndex + 1).' mismatch');
+                $result = $resultMap[$queryIndex];
+                ++$queryIndex;
+
+                return $result;
+            });
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('rollBack');
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->method('isVerbose')->willReturn(false);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(true);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, $p, $config, $logger);
+        self::assertSame(
+            'Aggregated 1 duplicate redirect groups (1 duplicate entries consolidated).',
+            $eventLogCleanup->aggregateRedirects(false, $output)
+        );
+    }
+
+    public function testAggregateRedirectsRealRunNothingToDo(): void
+    {
+        $findDuplicatesResult = $this->createMock(Result::class);
+        $findDuplicatesResult->expects(self::once())->method('fetchAllAssociative')->willReturn([]);
+
+        $orphanCountResult = $this->createMock(Result::class);
+        $orphanCountResult->expects(self::once())->method('fetchOne')->willReturn(0);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))->method('executeQuery')
+            ->willReturnCallback(static function () use (&$findDuplicatesResult, &$orphanCountResult): Result {
+                if (null !== $findDuplicatesResult) {
+                    $result = $findDuplicatesResult;
+                    $findDuplicatesResult = null;
+
+                    return $result;
+                }
+
+                return $orphanCountResult;
+            });
+        $connection->expects(self::never())->method('beginTransaction');
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->method('isVerbose')->willReturn(false);
+
+        $config = $this->createMock(Config::class);
+        $config->method('isPublished')->willReturn(true);
+
+        $logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
+        $eventLogCleanup = new EventLogCleanup($connection, 'prefix_table_', $config, $logger);
+        self::assertSame(
+            'No duplicate redirects or orphan hits found. Nothing to do.',
+            $eventLogCleanup->aggregateRedirects(false, $output)
+        );
+    }
+
     public static function runProvider(): \Generator
     {
         $daysOld = 4;


### PR DESCRIPTION
 ## Summary                                                                                                                                                  
  When multiple Messenger workers send emails concurrently, `TrackableModel::getTrackablesByUrls()` creates duplicate `page_redirects` entries — same URL, same email, different IDs. This adds an `--aggregate-redirects` option to the housekeeping command that consolidates these duplicates without breaking existing tracking URLs.                                                                                                                                     
                                                                                                                                                              
  ### What it does                                                                                                                                            
  Two-phase aggregation:                                                                                                                                      
                                                                                                                                                              
  **Phase A — Duplicate consolidation:**                                                                                                                      
  - Finds duplicate redirects for the same URL within the same email (grouped by url + channel + channel_id)
  - Picks a winner (lowest ID) per group
  - Moves all page_hits from losers to winner
  - Consolidates trackable and redirect stats
  - Cleans up loser entries

  **Phase B — Orphan hit cleanup:**
  - Finds page_hits referencing redirects without trackable entries
  - Reassigns them to the correct winner (matched by URL and email)
  - Updates winner stats accordingly

  ### Usage
  ```bash
  # Preview
  bin/console leuchtfeuer:housekeeping --aggregate-redirects --dry-run

  # Run
  bin/console leuchtfeuer:housekeeping --aggregate-redirects
```
<img width="934" height="34" alt="Bildschirmfoto 2026-03-01 um 18 12 13" src="https://github.com/user-attachments/assets/d017185d-532b-4f76-8497-1580a1e39e63" />

### Why this happens

  With multiple messenger:consume workers, concurrent calls to getTrackablesByUrls() race to create the same redirect — each worker inserts its own row before seeing the other's. The tracking links all work (they resolve to the same URL), but stats are fragmented across duplicate entries.

 ###  Tested on

  - Mautic 7.0.1
  - PHP 8.3.6
  - 100k+ contacts with 4 concurrent workers
 
### Before with 4 consume email workers and 4 different tracking ids for same url:
<img width="1178" height="1028" alt="Before" src="https://github.com/user-attachments/assets/be831462-5e77-40a8-8074-f0c5fda11bff" />


### After 
<img width="1178" height="1028" alt="After" src="https://github.com/user-attachments/assets/50d17c72-f246-4f00-8adc-8cb89a2fce73" />

