### PR TITLE
MTC-10317 Add email exclusion by ID to event log cleanup command 

### DIFF
--- a/Command/EventLogCleanupCommand.php
+++ b/Command/EventLogCleanupCommand.php
@@ -41,7 +41,7 @@ class EventLogCleanupCommand extends Command
                     new InputOption('email-stats', 'm', InputOption::VALUE_NONE, 'Purge only Email Stats Records where the referenced email entry is currently not published and purge Email Stats Devices. Important: If referenced email is ever switched back to published, the contacts will get the email again.'),
                     new InputOption('email-stats-tokens', 't', InputOption::VALUE_NONE, 'Set only tokens fields in Email Stats Records to NULL. Important: This option can not be combined with any "-c", "-l" or "-m" flag in one command. And: If the option flag "-t" is not set, the NULL setting of tokens will not be done with the basis command, so if you just run mautic:leuchtfeuer:housekeeping without a flag)'),
                     new InputOption('cmp-id', 'i', InputOption::VALUE_OPTIONAL, 'Delete only campaign_lead_eventLog for a specific CampaignID. Implies --campaign-lead.', 'none'),
-                    new InputOption('exclude-emails', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of email IDs to exclude from deletion (e.g., 1,44,61). Works with --email-stats and --email-stats-tokens.', null),
+                    new InputOption('exclude-emails', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of email IDs to exclude from deletion (e.g., 1,44,61). Works with --email-stats and --email-stats-tokens.', null),
                     new InputOption('optimize-tables', 'o', InputOption::VALUE_NONE, 'Optimize all database tables after cleanup.'),
                 ]
             )
@@ -89,21 +89,7 @@ class EventLogCleanupCommand extends Command
         $daysOld                              = (int) $input->getOption('days-old');
         $dryRun                               = $input->getOption('dry-run');
         $campaignId                           = 'none' === $input->getOption('cmp-id') ? null : (int) $input->getOption('cmp-id');
-        $excludeEmails                        = null;
-        $excludeEmailsRaw                     = $input->getOption('exclude-emails');
-        if (null !== $excludeEmailsRaw && '' !== $excludeEmailsRaw) {
-            $excludeEmails = array_values(array_filter(
-                array_map('intval', array_filter(explode(',', $excludeEmailsRaw), 'ctype_digit')),
-                static fn (int $id): bool => $id > 0
-            ));
-            if (empty($excludeEmails)) {
-                $excludeEmails = null;
-            }
-        }
-
-        if (null !== $excludeEmailsRaw && '' !== $excludeEmailsRaw && null === $excludeEmails) {
-            $output->writeln('<comment>Warning: --exclude-emails contained no valid IDs and will be ignored.</comment>');
-        }
+        $excludeEmails                        = $this->parseExcludeEmailIds($input, $output);
 
         $operations                           = [
             EventLogCleanup::CAMPAIGN_LEAD_EVENTS => $input->getOption('campaign-lead') || null !== $campaignId,
@@ -154,5 +140,41 @@ class EventLogCleanupCommand extends Command
         }
 
         return 0;
+    }
+
+    /**
+     * @return list<int>|null
+     */
+    private function parseExcludeEmailIds(InputInterface $input, OutputInterface $output): ?array
+    {
+        $rawValue = $input->getOption('exclude-emails');
+
+        if (null === $rawValue || '' === $rawValue) {
+            return null;
+        }
+
+        $ids = [];
+
+        foreach (explode(',', $rawValue) as $part) {
+            $part = trim($part);
+
+            if (!ctype_digit($part)) {
+                continue;
+            }
+
+            $id = (int) $part;
+
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+
+        if ([] === $ids) {
+            $output->writeln('<comment>Warning: --exclude-emails contained no valid IDs and will be ignored.</comment>');
+
+            return null;
+        }
+
+        return array_values($ids);
     }
 }

--- a/Command/EventLogCleanupCommand.php
+++ b/Command/EventLogCleanupCommand.php
@@ -41,6 +41,7 @@ class EventLogCleanupCommand extends Command
                     new InputOption('email-stats', 'm', InputOption::VALUE_NONE, 'Purge only Email Stats Records where the referenced email entry is currently not published and purge Email Stats Devices. Important: If referenced email is ever switched back to published, the contacts will get the email again.'),
                     new InputOption('email-stats-tokens', 't', InputOption::VALUE_NONE, 'Set only tokens fields in Email Stats Records to NULL. Important: This option can not be combined with any "-c", "-l" or "-m" flag in one command. And: If the option flag "-t" is not set, the NULL setting of tokens will not be done with the basis command, so if you just run mautic:leuchtfeuer:housekeeping without a flag)'),
                     new InputOption('cmp-id', 'i', InputOption::VALUE_OPTIONAL, 'Delete only campaign_lead_eventLog for a specific CampaignID. Implies --campaign-lead.', 'none'),
+                    new InputOption('exclude-emails', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of email IDs to exclude from deletion (e.g., 1,44,61). Works with --email-stats and --email-stats-tokens.', null),
                     new InputOption('optimize-tables', 'o', InputOption::VALUE_NONE, 'Optimize all database tables after cleanup.'),
                 ]
             )
@@ -76,6 +77,9 @@ class EventLogCleanupCommand extends Command
 
                 Purge only page_hits records
                 <info>php %command.full_name% --page-hits</info>
+
+                Exclude specific emails from cleanup:
+                <info>php %command.full_name% --email-stats --exclude-emails=1,44,61</info>
                 EOT
             );
     }
@@ -85,6 +89,22 @@ class EventLogCleanupCommand extends Command
         $daysOld                              = (int) $input->getOption('days-old');
         $dryRun                               = $input->getOption('dry-run');
         $campaignId                           = 'none' === $input->getOption('cmp-id') ? null : (int) $input->getOption('cmp-id');
+        $excludeEmails                        = null;
+        $excludeEmailsRaw                     = $input->getOption('exclude-emails');
+        if (null !== $excludeEmailsRaw && '' !== $excludeEmailsRaw) {
+            $excludeEmails = array_values(array_filter(
+                array_map('intval', array_filter(explode(',', $excludeEmailsRaw), 'ctype_digit')),
+                static fn (int $id): bool => $id > 0
+            ));
+            if (empty($excludeEmails)) {
+                $excludeEmails = null;
+            }
+        }
+
+        if (null !== $excludeEmailsRaw && '' !== $excludeEmailsRaw && null === $excludeEmails) {
+            $output->writeln('<comment>Warning: --exclude-emails contained no valid IDs and will be ignored.</comment>');
+        }
+
         $operations                           = [
             EventLogCleanup::CAMPAIGN_LEAD_EVENTS => $input->getOption('campaign-lead') || null !== $campaignId,
             EventLogCleanup::LEAD_EVENTS          => $input->getOption('lead'),
@@ -110,7 +130,8 @@ class EventLogCleanupCommand extends Command
                 $campaignId,
                 $dryRun,
                 $operations,
-                $output
+                $output,
+                $excludeEmails
             );
         } catch (\Throwable $e) {
             $output->writeln(sprintf('<error>Deletion of Log Rows failed because of database error: %s</error>', $e->getMessage()));

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ By default, entries older than 365 days are deleted from the CampaignLeadEventLo
 -t  | --email-stats-tokens      | Only set tokens fields in Email Stats Records to NULL instead of deleting the whole record
 -l  | --lead                    | Only entries from the lead_event_log table will be deleted.
 -p  | --page-hits               | Only entries from the page_hits table will be deleted.
+    | --exclude-emails          | Exclude specific email IDs from event log cleanup. Accepts comma-separated list of email IDs (e.g., 1,44,61). Works with --email-stats and --email-stats-tokens.
 ```
 
 ### Notice

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\LeuchtfeuerHousekeepingBundle\Service;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use MauticPlugin\LeuchtfeuerHousekeepingBundle\Integration\Config;
 use Psr\Log\LoggerInterface;
@@ -107,8 +108,9 @@ class EventLogCleanup
 
     /**
      * @param non-empty-array<string, bool> $operations
+     * @param list<int>|null                $excludeEmailIds
      */
-    public function deleteEventLogEntries(int $daysOld, ?int $campaignId, bool $dryRun, array $operations, OutputInterface $output): string
+    public function deleteEventLogEntries(int $daysOld, ?int $campaignId, bool $dryRun, array $operations, OutputInterface $output, ?array $excludeEmailIds = null): string
     {
         if (!$this->config->isPublished()) {
             return 'Housekeeping by Leuchtfeuer is currently not enabled. To use it, please enable the plugin in your Mautic plugin management.';
@@ -130,6 +132,26 @@ class EventLogCleanup
             unset($operations[self::EMAIL_STATS]);
             $operations[self::EMAIL_STATS_DEVICES] = true;
             $operations[self::EMAIL_STATS]         = true;
+        }
+
+        if (null !== $excludeEmailIds && [] !== $excludeEmailIds) {
+            if ($operations[self::EMAIL_STATS] ?? false) {
+                $this->queriesTemplate[self::EMAIL_STATS] .= ' AND '.self::PREFIX.'email_stats.email_id NOT IN (:excludeEmailIds)';
+                $this->params[self::EMAIL_STATS]['excludeEmailIds'] = $excludeEmailIds;
+                $this->types[self::EMAIL_STATS]['excludeEmailIds']  = ArrayParameterType::INTEGER;
+            }
+
+            if ($operations[self::EMAIL_STATS_TOKENS] ?? false) {
+                $this->queriesTemplate[self::EMAIL_STATS_TOKENS] .= ' AND '.self::PREFIX.'email_stats.email_id NOT IN (:excludeEmailIds)';
+                $this->params[self::EMAIL_STATS_TOKENS]['excludeEmailIds'] = $excludeEmailIds;
+                $this->types[self::EMAIL_STATS_TOKENS]['excludeEmailIds']  = ArrayParameterType::INTEGER;
+            }
+
+            if ($operations[self::EMAIL_STATS_DEVICES] ?? false) {
+                $this->queriesTemplate[self::EMAIL_STATS_DEVICES] .= ' AND '.self::PREFIX.'email_stats_devices.stat_id NOT IN (SELECT id FROM '.self::PREFIX.'email_stats WHERE email_id IN (:excludeEmailIds))';
+                $this->params[self::EMAIL_STATS_DEVICES]['excludeEmailIds'] = $excludeEmailIds;
+                $this->types[self::EMAIL_STATS_DEVICES]['excludeEmailIds']  = ArrayParameterType::INTEGER;
+            }
         }
 
         $result = [

--- a/Service/EventLogCleanup.php
+++ b/Service/EventLogCleanup.php
@@ -48,7 +48,7 @@ class EventLogCleanup
     ];
 
     /**
-     * @var array<string, array<string, int>>
+     * @var array<string, array<string, int|list<int>>>
      */
     private array $params = [
         self::CAMPAIGN_LEAD_EVENTS => [

--- a/Tests/Functional/EventLogCleanupCommandTest.php
+++ b/Tests/Functional/EventLogCleanupCommandTest.php
@@ -694,6 +694,233 @@ class EventLogCleanupCommandTest extends MauticMysqlTestCase
         Assert::assertNotNull($stats[0]->getEmail());
     }
 
+    // ========== Exclude Emails Tests ==========
+
+    public function testExcludeEmailsPreservesSpecificEmailStats(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-stats@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $excludedEmail = $this->fixtureHelper->createEmail('Excluded Email', false);
+        $otherEmail    = $this->fixtureHelper->createEmail('Other Unpublished Email', false);
+
+        $this->fixtureHelper->createEmailStat($contact, $excludedEmail, $oldDate);
+        $this->fixtureHelper->createEmailStat($contact, $otherEmail, $oldDate);
+
+        $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--exclude-emails' => (string) $excludedEmail->getId(),
+        ]);
+
+        $this->em->clear();
+
+        // Only the excluded email stat should remain
+        $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(1, $stats);
+        Assert::assertEquals($excludedEmail->getId(), $stats[0]->getEmail()->getId());
+    }
+
+    public function testExcludeEmailsPreservesTokensForSpecificEmails(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-tokens@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $excludedEmail = $this->fixtureHelper->createEmail('Excluded Tokens Email', true);
+        $otherEmail    = $this->fixtureHelper->createEmail('Other Tokens Email', true);
+
+        $excludedStat = $this->fixtureHelper->createEmailStat($contact, $excludedEmail, $oldDate, ['token1' => 'value1']);
+        $otherStat    = $this->fixtureHelper->createEmailStat($contact, $otherEmail, $oldDate, ['token2' => 'value2']);
+
+        $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'           => 30,
+            '--email-stats-tokens' => true,
+            '--exclude-emails'     => (string) $excludedEmail->getId(),
+        ]);
+
+        $this->em->clear();
+
+        $allStats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(2, $allStats);
+
+        $statsById = [];
+        foreach ($allStats as $stat) {
+            $statsById[$stat->getEmail()->getId()] = $stat;
+        }
+
+        // Excluded email tokens should remain intact
+        Assert::assertNotNull($statsById[$excludedEmail->getId()]->getTokens());
+        // Other email tokens should be nullified
+        Assert::assertNull($statsById[$otherEmail->getId()]->getTokens());
+    }
+
+    public function testExcludeEmailsPreservesDevicesForSpecificEmails(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-devices@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $excludedEmail = $this->fixtureHelper->createEmail('Excluded Devices Email', false);
+        $otherEmail    = $this->fixtureHelper->createEmail('Other Devices Email', false);
+
+        $excludedStat = $this->fixtureHelper->createEmailStat($contact, $excludedEmail, $oldDate);
+        $otherStat    = $this->fixtureHelper->createEmailStat($contact, $otherEmail, $oldDate);
+        $this->fixtureHelper->createEmailStatDevice($excludedStat, $oldDate);
+        $this->fixtureHelper->createEmailStatDevice($otherStat, $oldDate);
+
+        $commandTester = $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--exclude-emails' => (string) $excludedEmail->getId(),
+        ]);
+
+        $this->em->clear();
+
+        // Excluded email stat (and device) should remain; other should be deleted
+        $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(1, $stats);
+        Assert::assertEquals($excludedEmail->getId(), $stats[0]->getEmail()->getId());
+
+        // The output should mention email_stats_devices were deleted
+        $output = $commandTester->getDisplay();
+        Assert::assertStringContainsString('email_stats_devices', $output);
+    }
+
+    public function testExcludeEmailsAcceptsMultipleIds(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-multi@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $email1 = $this->fixtureHelper->createEmail('Excluded Email 1', false);
+        $email2 = $this->fixtureHelper->createEmail('Excluded Email 2', false);
+        $email3 = $this->fixtureHelper->createEmail('To Be Deleted Email', false);
+
+        $this->fixtureHelper->createEmailStat($contact, $email1, $oldDate);
+        $this->fixtureHelper->createEmailStat($contact, $email2, $oldDate);
+        $this->fixtureHelper->createEmailStat($contact, $email3, $oldDate);
+
+        $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--exclude-emails' => $email1->getId().','.$email2->getId(),
+        ]);
+
+        $this->em->clear();
+
+        // email1 and email2 stats should remain; email3 should be deleted
+        $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(2, $stats);
+
+        $emailIds = array_map(static fn (EmailStat $s): int => $s->getEmail()->getId(), $stats);
+        Assert::assertContains($email1->getId(), $emailIds);
+        Assert::assertContains($email2->getId(), $emailIds);
+        Assert::assertNotContains($email3->getId(), $emailIds);
+    }
+
+    public function testExcludeEmailsHasNoEffectOnNonEmailOperations(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-no-effect@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $this->fixtureHelper->createLeadEventLog($contact, $oldDate);
+
+        $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--lead'           => true,
+            '--exclude-emails' => '999',
+        ]);
+
+        $this->em->clear();
+
+        // lead_event_log should still be deleted (--exclude-emails does not affect it)
+        Assert::assertCount(0, $this->em->getRepository(LeadEventLog::class)->findBy(['lead' => $contact->getId()]));
+    }
+
+    public function testExcludeEmailsWithInvalidInputIsIgnored(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $commandTester = $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--exclude-emails' => 'abc,xyz',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        Assert::assertStringContainsString('Warning: --exclude-emails contained no valid IDs', $output);
+        Assert::assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testExcludeEmailsExtractsValidIdsFromMixedInput(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-mixed@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $validEmail   = $this->fixtureHelper->createEmail('Valid Excluded Email', false);
+        $invalidEmail = $this->fixtureHelper->createEmail('Not Excluded Email', false);
+
+        $this->fixtureHelper->createEmailStat($contact, $validEmail, $oldDate);
+        $this->fixtureHelper->createEmailStat($contact, $invalidEmail, $oldDate);
+
+        // Pass mixed valid/invalid IDs — only valid ones should be used
+        $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--exclude-emails' => $validEmail->getId().',abc,xyz',
+        ]);
+
+        $this->em->clear();
+
+        // Only the validEmail stat should remain
+        $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(1, $stats);
+        Assert::assertEquals($validEmail->getId(), $stats[0]->getEmail()->getId());
+    }
+
+    public function testExcludeEmailsDryRunShowsCorrectCounts(): void
+    {
+        $this->fixtureHelper->enablePlugin();
+
+        $contact = $this->fixtureHelper->createContact('exclude-dryrun@test.com');
+        $oldDate = $this->fixtureHelper->daysAgo(400);
+
+        $excludedEmail = $this->fixtureHelper->createEmail('Excluded Dry Run Email', false);
+        $otherEmail    = $this->fixtureHelper->createEmail('Other Dry Run Email', false);
+
+        $this->fixtureHelper->createEmailStat($contact, $excludedEmail, $oldDate);
+        $this->fixtureHelper->createEmailStat($contact, $otherEmail, $oldDate);
+
+        $commandTester = $this->testSymfonyCommand('leuchtfeuer:housekeeping', [
+            '--days-old'       => 30,
+            '--email-stats'    => true,
+            '--dry-run'        => true,
+            '--exclude-emails' => (string) $excludedEmail->getId(),
+        ]);
+
+        $this->em->clear();
+
+        // Both stats should remain (dry run)
+        $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
+        Assert::assertCount(2, $stats);
+
+        // Only 1 row would have been deleted (the non-excluded one)
+        $output = $commandTester->getDisplay();
+        Assert::assertStringContainsString('1 email_stats', $output);
+        Assert::assertStringContainsString('would have been deleted', $output);
+        Assert::assertStringContainsString('This is a dry run', $output);
+    }
+
     // ========== Edge Case Tests ==========
 
     public function testNoRecordsToDelete(): void

--- a/Tests/Functional/EventLogCleanupCommandTest.php
+++ b/Tests/Functional/EventLogCleanupCommandTest.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\LeuchtfeuerHousekeepingBundle\Tests\Functional;
 use Mautic\CampaignBundle\Entity\LeadEventLog as CampaignLeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Stat as EmailStat;
+use Mautic\EmailBundle\Entity\StatDevice;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\LeuchtfeuerHousekeepingBundle\Tests\Fixtures\FixtureHelper;
@@ -87,6 +88,9 @@ class EventLogCleanupCommandTest extends MauticMysqlTestCase
         // Email stats should be deleted for unpublished emails
         $emailStats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
         Assert::assertCount(0, $emailStats);
+
+        // Email stat device should also be deleted (stat was for unpublished email)
+        Assert::assertCount(0, $this->em->getRepository(StatDevice::class)->findBy(['stat' => $stat->getId()]));
 
         // Tokens should NOT be affected (default behavior excludes tokens)
         $output = $commandTester->getDisplay();
@@ -275,6 +279,7 @@ class EventLogCleanupCommandTest extends MauticMysqlTestCase
         Assert::assertCount(0, $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]));
 
         // Email stat devices should also be deleted
+        Assert::assertCount(0, $this->em->getRepository(StatDevice::class)->findBy(['stat' => $stat->getId()]));
         $output = $commandTester->getDisplay();
         Assert::assertStringContainsString('email_stats_devices', $output);
 
@@ -785,6 +790,10 @@ class EventLogCleanupCommandTest extends MauticMysqlTestCase
         $stats = $this->em->getRepository(EmailStat::class)->findBy(['lead' => $contact->getId()]);
         Assert::assertCount(1, $stats);
         Assert::assertEquals($excludedEmail->getId(), $stats[0]->getEmail()->getId());
+
+        // Excluded stat device should remain; other stat device should be deleted
+        Assert::assertCount(1, $this->em->getRepository(StatDevice::class)->findBy(['stat' => $excludedStat->getId()]));
+        Assert::assertCount(0, $this->em->getRepository(StatDevice::class)->findBy(['stat' => $otherStat->getId()]));
 
         // The output should mention email_stats_devices were deleted
         $output = $commandTester->getDisplay();


### PR DESCRIPTION
## Summary
This PR adds the ability to exclude specific emails by ID from the event log cleanup command in the Housekeeping Bundle. This feature allows users to retain event logs for critical or protected email addresses while cleaning up others.

## Changes
- **Added `--exclude-emails` argument** to the `EventLogCleanupCommand` for specifying email IDs to exclude from cleanup
- **Improved argument parsing** with better validation and handling of email exclusion parameters
- **Added comprehensive functional tests** covering the new email exclusion functionality

The `-e` shortcut for `--exclude-emails` argument was not implemented, as it's already in use for `--env`